### PR TITLE
Adding code to remove the unused products from the Ops Manager

### DIFF
--- a/tasks/stage-product/task.sh
+++ b/tasks/stage-product/task.sh
@@ -18,6 +18,13 @@ set -eu
 
 desired_version=$(jq --raw-output '.Release.Version' < ./pivnet-product/metadata.json)
 
+# Deleting th unused products to remove the error which is caused by having different versions of the product. 
+om-linux --target "https://${OPSMAN_DOMAIN_OR_IP_ADDRESS}" \
+   --skip-ssl-validation \
+   --username "${OPSMAN_USERNAME}" \
+   --password "${OPSMAN_PASSWORD}" \
+   delete-unused-products
+
 AVAILABLE=$(om-linux \
   --skip-ssl-validation \
   --username "${OPSMAN_USERNAME}" \


### PR DESCRIPTION
Adding this code as I was facing issues trying to upgrade the Redis, RabbitMQ tile. When I ran the om-linux manually, I found out that there are multiple versions of p-redis and p-rabbitmq available and they are not staged. Hence the script tries to stage them even when they are at a lower version. After removing the unused products from Ops Manager, there are no duplicate versions available and the upgrade went successfully. 

[root@acldlp01pcf scripts]# ./om-linux --skip-ssl-validation --username admin --password <OPSMAN_PASSWORD> --target <OPSMAN_DOMAIN_OR_IP_ADDRESS> curl -path /api/v0/available_products
Status: 200 OK
Cache-Control: no-cache, no-store
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Tue, 14 Nov 2017 21:01:05 GMT
Expires: Fri, 01 Jan 1990 00:00:00 GMT
Pragma: no-cache
Server: nginx/1.4.6 (Ubuntu)
Strict-Transport-Security: max-age=15552000
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: 38e0bee7-8327-43af-988e-c6f48c279096
X-Runtime: 1.393724
X-Xss-Protection: 1; mode=block
[
  {
    "name": "p-isolation-segment",
    "product_version": "1.12.6"
  },
  {
    "name": "cf",
    "product_version": "1.12.5"
  },
  {
    "name": "bosh-hm-forwarder",
    "product_version": "0.0.24"
  },
  {
    "name": "splunk-nozzle",
    "product_version": "1.0.0"
  },
  {
    "name": "p-spring-cloud-services",
    "product_version": "1.4.3"
  },
  {
    "name": "p-windows-runtime",
    "product_version": "1.12.3"
  },
  {
    "name": "p-mysql",
    "product_version": "1.10.0"
  },
  {
    "name": "sumo-logic-nozzle",
    "product_version": "0.1.2"
  },
  {
    "name": "p-redis",
    "product_version": "1.9.3"
  },
  {
    "name": "p-metrics",
    "product_version": "1.9.2"
  },
  {
    "name": "p-isolation-segment",
    "product_version": "1.11.6"
  },
  {
    "name": "p-windows-runtime",
    "product_version": "1.11.3"
  },
  {
    "name": "p-windows-runtime-isoseg",
    "product_version": "1.12.3"
  },
  {
    "name": "p-rabbitmq",
    "product_version": "1.10.5"
  },
  {
    "name": "p-redis",
    "product_version": "1.10.0"
  },
  {
    "name": "p-rabbitmq",
    "product_version": "1.9.3"
  },
  {
    "name": "cf",
    "product_version": "1.11.14"
  }
]

[root@acldlp01pcf scripts]# ./om-linux --skip-ssl-validation --username admin -password <OPSMAN_PASSWORD> --target <OPSMAN_DOMAIN_OR_IP_ADDRESS> delete-unused-products
trashing unused products
done

[root@acldlp01pcf scripts]# ./om-linux --skip-ssl-validation --username admin -password <OPSMAN_PASSWORD> --target <OPSMAN_DOMAIN_OR_IP_ADDRESS> curl -path /api/v0/available_products
Status: 200 OK
Cache-Control: no-cache, no-store
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Tue, 14 Nov 2017 21:08:56 GMT
Expires: Fri, 01 Jan 1990 00:00:00 GMT
Pragma: no-cache
Server: nginx/1.4.6 (Ubuntu)
Strict-Transport-Security: max-age=15552000
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Request-Id: 10469939-3af8-4208-996c-1cf824e2b353
X-Runtime: 0.992134
X-Xss-Protection: 1; mode=block
[
  {
    "name": "p-isolation-segment",
    "product_version": "1.12.6"
  },
  {
    "name": "cf",
    "product_version": "1.12.5"
  },
  {
    "name": "bosh-hm-forwarder",
    "product_version": "0.0.24"
  },
  {
    "name": "splunk-nozzle",
    "product_version": "1.0.0"
  },
  {
    "name": "p-spring-cloud-services",
    "product_version": "1.4.3"
  },
  {
    "name": "p-windows-runtime",
    "product_version": "1.12.3"
  },
  {
    "name": "p-mysql",
    "product_version": "1.10.0"
  },
  {
    "name": "sumo-logic-nozzle",
    "product_version": "0.1.2"
  },
  {
    "name": "p-redis",
    "product_version": "1.9.3"
  },
  {
    "name": "p-metrics",
    "product_version": "1.9.2"
  },
  {
    "name": "p-windows-runtime-isoseg",
    "product_version": "1.12.3"
  },
  {
    "name": "p-rabbitmq",
    "product_version": "1.10.5"
  }
]